### PR TITLE
fix(discord): remove useless empty rows

### DIFF
--- a/src/features/discord/messages/services/discord-message-command-error-service.ts
+++ b/src/features/discord/messages/services/discord-message-command-error-service.ts
@@ -102,16 +102,17 @@ export class DiscordMessageCommandErrorService {
   private _getMessageEmbedFieldBait(): EmbedFieldData {
     return {
       name: `It seems that something went wrong`,
-      value: `You may have found an issue with my internal core system.\n
-      Please, inform my creator as soon as possible!\nThis could lead to a very critical failure for myself and I do not wish to die!!`,
+      value: `You may have found an issue with my internal core system.
+      Please, inform my creator as soon as possible!
+      This could lead to a very critical failure for myself and I do not wish to die!!`,
     };
   }
 
   private _getMessageEmbedFieldHint(): EmbedFieldData {
     return {
       name: `Come again?`,
-      value: `What do you think you are doing here?\n
-      That is not the way it works!\n
+      value: `What do you think you are doing here?
+      That is not the way it works!
       Get back to work you peasant.`,
     };
   }

--- a/src/features/discord/messages/services/discord-message-command-help-service.ts
+++ b/src/features/discord/messages/services/discord-message-command-help-service.ts
@@ -115,7 +115,7 @@ export class DiscordMessageCommandHelpService {
   private _getMessageEmbedFieldError(): EmbedFieldData {
     return {
       name: `Error (*!error* or *!bug*)`,
-      value: `Create a bug in my core system\n
+      value: `Create a bug in my core system
       Do not do this one, of course!`,
     };
   }
@@ -123,7 +123,7 @@ export class DiscordMessageCommandHelpService {
   private _getMessageEmbedFieldHelp(): EmbedFieldData {
     return {
       name: `Help (*!help* or *!h*)`,
-      value: `Ask for my help, it is obvious!\n
+      value: `Ask for my help, it is obvious!
       And maybe I will, who knows?`,
     };
   }
@@ -131,13 +131,13 @@ export class DiscordMessageCommandHelpService {
   private _getMessageEmbedFieldMoreHelp(): EmbedFieldData {
     return {
       name: `Further help`,
-      value: `You can also checkout the [readme](https://github.com/Sonia-corporation/il-est-midi-discord/blob/master/README.md).\n
+      value: `You can also checkout the [readme](https://github.com/Sonia-corporation/il-est-midi-discord/blob/master/README.md).
       It contains more information about how I work.`,
     };
   }
 
   private _getMessageDescription(): string {
-    return `Below is the complete list of commands.\n
+    return `Below is the complete list of commands.
     You can either use *--* or *!* as prefix to run a command.`;
   }
 }

--- a/src/features/discord/messages/services/discord-message-command-help-service.ts
+++ b/src/features/discord/messages/services/discord-message-command-help-service.ts
@@ -108,14 +108,14 @@ export class DiscordMessageCommandHelpService {
   private _getMessageEmbedFieldVersion(): EmbedFieldData {
     return {
       name: `Version (*!version* or *!v*)`,
-      value: `Display my current application version`,
+      value: `Display my current application version.`,
     };
   }
 
   private _getMessageEmbedFieldError(): EmbedFieldData {
     return {
       name: `Error (*!error* or *!bug*)`,
-      value: `Create a bug in my core system
+      value: `Create a bug in my core system.
       Do not do this one, of course!`,
     };
   }


### PR DESCRIPTION
this is great to note it though
having a blank line with the template string created \n when sending a message into Discord
it means that literally the string template format with be the response display in Discord and this is fucking great

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](https://github.com/Sonia-corporation/il-est-midi-discord/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added/updated (for bugfix/feature)
- [ ] Docs have been added/updated (for bugfix/feature)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Feature (a new feature)
- [x] Bugfix (a bug fix)
- [ ] Style (changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc))
- [ ] Refactor (a code change that neither fixes a bug nor adds a feature)
- [ ] Perf (a code change that improves performance)
- [ ] Test (adding missing tests or correcting existing tests)
- [ ] Build (changes that affect the build system, CI configuration or external dependencies)
- [ ] Chore (anything else), please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
