### PR TITLE
feat(discord): handle the case where discord send string error

### DIFF
--- a/src/features/discord/logger/services/discord-logger-error.service.ts
+++ b/src/features/discord/logger/services/discord-logger-error.service.ts
@@ -39,7 +39,7 @@ export class DiscordLoggerErrorService extends AbstractService {
     super(ServiceNameEnum.DISCORD_LOGGER_ERROR_SERVICE);
   }
 
-  public handleError(error: Readonly<Error>): void {
+  public handleError(error: Readonly<Error | string>): void {
     this._loggerService.error({
       context: this._serviceName,
       message: this._chalkService.text(error),
@@ -58,7 +58,7 @@ export class DiscordLoggerErrorService extends AbstractService {
   }
 
   private _getErrorMessageResponse(
-    error: Readonly<Error>
+    error: Readonly<Error | string>
   ): IDiscordMessageResponse {
     return {
       options: {
@@ -69,17 +69,24 @@ export class DiscordLoggerErrorService extends AbstractService {
     };
   }
 
-  private _getMessageEmbed(error: Readonly<Error>): MessageEmbedOptions {
-    return {
+  private _getMessageEmbed(
+    error: Readonly<Error | string>
+  ): MessageEmbedOptions {
+    const messageEmbedOptions: MessageEmbedOptions = {
       author: this._getMessageEmbedAuthor(),
       color: this._getMessageEmbedColor(),
-      description: this._getMessageEmbedDescription(error),
-      fields: this._getMessageEmbedFields(error),
       footer: this._getMessageEmbedFooter(),
       thumbnail: this._getMessageEmbedThumbnail(),
       timestamp: this._getMessageEmbedTimestamp(),
       title: this._getMessageEmbedTitle(error),
     };
+
+    if (!_.isString(error)) {
+      messageEmbedOptions.description = this._getMessageEmbedDescription(error);
+      messageEmbedOptions.fields = this._getMessageEmbedFields(error);
+    }
+
+    return messageEmbedOptions;
   }
 
   private _getMessageEmbedAuthor(): MessageEmbedAuthor {
@@ -111,7 +118,11 @@ export class DiscordLoggerErrorService extends AbstractService {
     return moment().toDate();
   }
 
-  private _getMessageEmbedTitle(error: Readonly<Error>): string {
+  private _getMessageEmbedTitle(error: Readonly<Error | string>): string {
+    if (_.isString(error)) {
+      return error;
+    }
+
     return error.name;
   }
 

--- a/src/features/discord/logger/services/discord-logger.service.ts
+++ b/src/features/discord/logger/services/discord-logger.service.ts
@@ -48,7 +48,7 @@ export class DiscordLoggerService extends AbstractService {
   }
 
   private _listenForErrors(): void {
-    this.discordClient.on(`error`, (error: Readonly<Error>): void => {
+    this.discordClient.on(`error`, (error: Readonly<Error | string>): void => {
       this._discordLoggerErrorService.handleError(error);
     });
 


### PR DESCRIPTION
I really have no idea if this is useful because the Discord type is Error, not Error | string.
Yet it seems that the logs detected an error by receiving a string.
At least the case is handle error

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](https://github.com/Sonia-corporation/il-est-midi-discord/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added/updated (for bugfix/feature)
- [ ] Docs have been added/updated (for bugfix/feature)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Feature (a new feature)
- [x] Bugfix (a bug fix)
- [ ] Style (changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc))
- [ ] Refactor (a code change that neither fixes a bug nor adds a feature)
- [ ] Perf (a code change that improves performance)
- [ ] Test (adding missing tests or correcting existing tests)
- [ ] Build (changes that affect the build system, CI configuration or external dependencies)
- [ ] Chore (anything else), please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
