### PR TITLE
fix(discord): always fetch the release notes for the current app version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8513,71 +8513,13 @@
       }
     },
     "eslint-plugin-typescript-sort-keys": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-typescript-sort-keys/-/eslint-plugin-typescript-sort-keys-1.0.2.tgz",
-      "integrity": "sha512-B2xVLmnz9ksP8hO49OBN7F/86+1fV9m8mtTTARzuH21R9R34ZPC+KE2naQfMolFjZwd5pISpFPR+IQ8s5j5fWg==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-typescript-sort-keys/-/eslint-plugin-typescript-sort-keys-0.10.0.tgz",
+      "integrity": "sha512-RmYTBe3Wa18jDbg4idAaMCCdADUvp2PDByrMqY1+9UwD3ftkd4qcyqIDsWs1qijnYZYJGdFe9yEQ8XzeXyPwxw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "~2.32.0",
-        "natural-compare-lite": "~1.4.0"
-      },
-      "dependencies": {
-        "@typescript-eslint/experimental-utils": {
-          "version": "2.32.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.32.0.tgz",
-          "integrity": "sha512-oDWuB2q5AXsQ/mLq2N4qtWiBASWXPf7KhqXgeGH4QsyVKx+km8F6Vfqd3bspJQyhyCqxcbLO/jKJuIV3DzHZ6A==",
-          "dev": true,
-          "requires": {
-            "@types/json-schema": "^7.0.3",
-            "@typescript-eslint/typescript-estree": "2.32.0",
-            "eslint-scope": "^5.0.0",
-            "eslint-utils": "^2.0.0"
-          }
-        },
-        "@typescript-eslint/typescript-estree": {
-          "version": "2.32.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.32.0.tgz",
-          "integrity": "sha512-hQpbWM/Y2iq6jB9FHYJBqa3h1R9IEGodOtajhb261cVHt9cz30AKjXM6WP7LxJdEPPlyJ9rPTZVgBUgZgiyPgw==",
-          "dev": true,
-          "requires": {
-            "debug": "^4.1.1",
-            "eslint-visitor-keys": "^1.1.0",
-            "glob": "^7.1.6",
-            "is-glob": "^4.0.1",
-            "lodash": "^4.17.15",
-            "semver": "^7.3.2",
-            "tsutils": "^3.17.1"
-          }
-        },
-        "eslint-utils": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
-          "integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
-          "dev": true,
-          "requires": {
-            "eslint-visitor-keys": "^1.1.0"
-          }
-        },
-        "glob": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "semver": {
-          "version": "7.3.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-          "dev": true
-        }
+        "natural-compare-lite": "~1.4.0",
+        "requireindex": "~1.2.0"
       }
     },
     "eslint-rule-composer": {

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "eslint-plugin-jest": "23.13.1",
     "eslint-plugin-prettier": "3.1.3",
     "eslint-plugin-rxjs": "0.0.2-beta.20",
-    "eslint-plugin-typescript-sort-keys": "1.0.2",
+    "eslint-plugin-typescript-sort-keys": "0.10.0",
     "fs-extra": "9.0.0",
     "husky": "4.2.5",
     "jest": "26.0.1",

--- a/src/features/app/services/config/app-config-mutator.service.spec.ts
+++ b/src/features/app/services/config/app-config-mutator.service.spec.ts
@@ -604,84 +604,6 @@ describe(`AppConfigMutationService`, (): void => {
     });
   });
 
-  describe(`updateVersion()`, (): void => {
-    let version: string;
-
-    let configServiceGetUpdatedStringSpy: jest.SpyInstance;
-
-    beforeEach((): void => {
-      service = AppConfigMutatorService.getInstance();
-      version = `dummy-version`;
-      appConfigCoreService.version = `version`;
-
-      configServiceGetUpdatedStringSpy = jest
-        .spyOn(configService, `getUpdatedString`)
-        .mockReturnValue(`dummy-version`);
-    });
-
-    it(`should get the updated string`, (): void => {
-      expect.assertions(2);
-
-      service.updateVersion(version);
-
-      expect(configServiceGetUpdatedStringSpy).toHaveBeenCalledTimes(1);
-      expect(configServiceGetUpdatedStringSpy).toHaveBeenCalledWith({
-        context: `AppConfigMutatorService`,
-        newValue: `dummy-version`,
-        oldValue: `version`,
-        valueName: `version`,
-      } as IConfigUpdateString);
-    });
-
-    it(`should update the app config version with the updated string`, (): void => {
-      expect.assertions(1);
-
-      service.updateVersion(version);
-
-      expect(appConfigCoreService.version).toStrictEqual(`dummy-version`);
-    });
-  });
-
-  describe(`updateReleaseDate()`, (): void => {
-    let releaseDate: string;
-
-    let configServiceGetUpdatedDateSpy: jest.SpyInstance;
-
-    beforeEach((): void => {
-      service = AppConfigMutatorService.getInstance();
-      releaseDate = `dummy-release-date`;
-      appConfigCoreService.releaseDate = `release-date`;
-
-      configServiceGetUpdatedDateSpy = jest
-        .spyOn(configService, `getUpdatedDate`)
-        .mockReturnValue(`dummy-release-date`);
-    });
-
-    it(`should get the updated string`, (): void => {
-      expect.assertions(2);
-
-      service.updateReleaseDate(releaseDate);
-
-      expect(configServiceGetUpdatedDateSpy).toHaveBeenCalledTimes(1);
-      expect(configServiceGetUpdatedDateSpy).toHaveBeenCalledWith({
-        context: `AppConfigMutatorService`,
-        newValue: `dummy-release-date`,
-        oldValue: `release-date`,
-        valueName: `release date`,
-      } as IConfigUpdateString);
-    });
-
-    it(`should update the app config release date with the updated string`, (): void => {
-      expect.assertions(1);
-
-      service.updateReleaseDate(releaseDate);
-
-      expect(appConfigCoreService.releaseDate).toStrictEqual(
-        `dummy-release-date`
-      );
-    });
-  });
-
   describe(`updateInitializationDate()`, (): void => {
     let initializationDate: string;
 
@@ -760,41 +682,43 @@ describe(`AppConfigMutationService`, (): void => {
     });
   });
 
-  describe(`updateTotalReleaseCount()`, (): void => {
-    let totalReleaseCount: number;
+  describe(`updateReleaseDate()`, (): void => {
+    let releaseDate: string;
 
-    let configServiceGetUpdatedNumberSpy: jest.SpyInstance;
+    let configServiceGetUpdatedDateSpy: jest.SpyInstance;
 
     beforeEach((): void => {
       service = AppConfigMutatorService.getInstance();
-      totalReleaseCount = 8;
-      appConfigCoreService.totalReleaseCount = 5;
+      releaseDate = `dummy-release-date`;
+      appConfigCoreService.releaseDate = `release-date`;
 
-      configServiceGetUpdatedNumberSpy = jest
-        .spyOn(configService, `getUpdatedNumber`)
-        .mockReturnValue(8);
+      configServiceGetUpdatedDateSpy = jest
+        .spyOn(configService, `getUpdatedDate`)
+        .mockReturnValue(`dummy-release-date`);
     });
 
-    it(`should get the updated number`, (): void => {
+    it(`should get the updated string`, (): void => {
       expect.assertions(2);
 
-      service.updateTotalReleaseCount(totalReleaseCount);
+      service.updateReleaseDate(releaseDate);
 
-      expect(configServiceGetUpdatedNumberSpy).toHaveBeenCalledTimes(1);
-      expect(configServiceGetUpdatedNumberSpy).toHaveBeenCalledWith({
+      expect(configServiceGetUpdatedDateSpy).toHaveBeenCalledTimes(1);
+      expect(configServiceGetUpdatedDateSpy).toHaveBeenCalledWith({
         context: `AppConfigMutatorService`,
-        newValue: 8,
-        oldValue: 5,
-        valueName: `total release count`,
-      } as IConfigUpdateNumber);
+        newValue: `dummy-release-date`,
+        oldValue: `release-date`,
+        valueName: `release date`,
+      } as IConfigUpdateString);
     });
 
-    it(`should update the app config total release count with the updated number`, (): void => {
+    it(`should update the app config release date with the updated string`, (): void => {
       expect.assertions(1);
 
-      service.updateTotalReleaseCount(totalReleaseCount);
+      service.updateReleaseDate(releaseDate);
 
-      expect(appConfigCoreService.totalReleaseCount).toStrictEqual(8);
+      expect(appConfigCoreService.releaseDate).toStrictEqual(
+        `dummy-release-date`
+      );
     });
   });
 
@@ -836,6 +760,82 @@ describe(`AppConfigMutationService`, (): void => {
       expect(appConfigCoreService.releaseNotes).toStrictEqual(
         `dummy-release-notes`
       );
+    });
+  });
+
+  describe(`updateTotalReleaseCount()`, (): void => {
+    let totalReleaseCount: number;
+
+    let configServiceGetUpdatedNumberSpy: jest.SpyInstance;
+
+    beforeEach((): void => {
+      service = AppConfigMutatorService.getInstance();
+      totalReleaseCount = 8;
+      appConfigCoreService.totalReleaseCount = 5;
+
+      configServiceGetUpdatedNumberSpy = jest
+        .spyOn(configService, `getUpdatedNumber`)
+        .mockReturnValue(8);
+    });
+
+    it(`should get the updated number`, (): void => {
+      expect.assertions(2);
+
+      service.updateTotalReleaseCount(totalReleaseCount);
+
+      expect(configServiceGetUpdatedNumberSpy).toHaveBeenCalledTimes(1);
+      expect(configServiceGetUpdatedNumberSpy).toHaveBeenCalledWith({
+        context: `AppConfigMutatorService`,
+        newValue: 8,
+        oldValue: 5,
+        valueName: `total release count`,
+      } as IConfigUpdateNumber);
+    });
+
+    it(`should update the app config total release count with the updated number`, (): void => {
+      expect.assertions(1);
+
+      service.updateTotalReleaseCount(totalReleaseCount);
+
+      expect(appConfigCoreService.totalReleaseCount).toStrictEqual(8);
+    });
+  });
+
+  describe(`updateVersion()`, (): void => {
+    let version: string;
+
+    let configServiceGetUpdatedStringSpy: jest.SpyInstance;
+
+    beforeEach((): void => {
+      service = AppConfigMutatorService.getInstance();
+      version = `dummy-version`;
+      appConfigCoreService.version = `version`;
+
+      configServiceGetUpdatedStringSpy = jest
+        .spyOn(configService, `getUpdatedString`)
+        .mockReturnValue(`dummy-version`);
+    });
+
+    it(`should get the updated string`, (): void => {
+      expect.assertions(2);
+
+      service.updateVersion(version);
+
+      expect(configServiceGetUpdatedStringSpy).toHaveBeenCalledTimes(1);
+      expect(configServiceGetUpdatedStringSpy).toHaveBeenCalledWith({
+        context: `AppConfigMutatorService`,
+        newValue: `dummy-version`,
+        oldValue: `version`,
+        valueName: `version`,
+      } as IConfigUpdateString);
+    });
+
+    it(`should update the app config version with the updated string`, (): void => {
+      expect.assertions(1);
+
+      service.updateVersion(version);
+
+      expect(appConfigCoreService.version).toStrictEqual(`dummy-version`);
     });
   });
 });

--- a/src/features/app/services/config/app-config-mutator.service.ts
+++ b/src/features/app/services/config/app-config-mutator.service.ts
@@ -48,38 +48,18 @@ export class AppConfigMutatorService extends AbstractConfigService<IAppConfig> {
 
   public updateConfig(config?: Readonly<PartialNested<IAppConfig>>): void {
     if (!_.isNil(config)) {
-      this.updateVersion(config.version);
-      this.updateReleaseDate(config.releaseDate);
       this.updateInitializationDate(config.initializationDate);
-      this.updateTotalReleaseCount(config.totalReleaseCount);
-      this.updateReleaseNotes(config.releaseNotes);
       this.updateProductionState(config.isProduction);
+      this.updateReleaseDate(config.releaseDate);
+      this.updateReleaseNotes(config.releaseNotes);
+      this.updateTotalReleaseCount(config.totalReleaseCount);
+      this.updateVersion(config.version);
 
       this._loggerService.debug({
         context: this._serviceName,
         message: this._chalkService.text(`configuration updated`),
       });
     }
-  }
-
-  public updateVersion(version?: Readonly<string>): void {
-    this._appConfigCoreService.version = this._configService.getUpdatedString({
-      context: this._serviceName,
-      newValue: version,
-      oldValue: this._appConfigService.getVersion(),
-      valueName: AppConfigValueNameEnum.VERSION,
-    });
-  }
-
-  public updateReleaseDate(releaseDate?: Readonly<string>): void {
-    this._appConfigCoreService.releaseDate = this._configService.getUpdatedDate(
-      {
-        context: this._serviceName,
-        newValue: releaseDate,
-        oldValue: this._appConfigService.getReleaseDate(),
-        valueName: AppConfigValueNameEnum.RELEASE_DATE,
-      }
-    );
   }
 
   public updateInitializationDate(initializationDate?: Readonly<string>): void {
@@ -104,13 +84,13 @@ export class AppConfigMutatorService extends AbstractConfigService<IAppConfig> {
     );
   }
 
-  public updateTotalReleaseCount(totalReleaseCount?: Readonly<number>): void {
-    this._appConfigCoreService.totalReleaseCount = this._configService.getUpdatedNumber(
+  public updateReleaseDate(releaseDate?: Readonly<string>): void {
+    this._appConfigCoreService.releaseDate = this._configService.getUpdatedDate(
       {
         context: this._serviceName,
-        newValue: totalReleaseCount,
-        oldValue: this._appConfigService.getTotalReleaseCount(),
-        valueName: AppConfigValueNameEnum.TOTAL_RELEASE_COUNT,
+        newValue: releaseDate,
+        oldValue: this._appConfigService.getReleaseDate(),
+        valueName: AppConfigValueNameEnum.RELEASE_DATE,
       }
     );
   }
@@ -125,6 +105,26 @@ export class AppConfigMutatorService extends AbstractConfigService<IAppConfig> {
         valueName: AppConfigValueNameEnum.RELEASE_NOTES,
       }
     );
+  }
+
+  public updateTotalReleaseCount(totalReleaseCount?: Readonly<number>): void {
+    this._appConfigCoreService.totalReleaseCount = this._configService.getUpdatedNumber(
+      {
+        context: this._serviceName,
+        newValue: totalReleaseCount,
+        oldValue: this._appConfigService.getTotalReleaseCount(),
+        valueName: AppConfigValueNameEnum.TOTAL_RELEASE_COUNT,
+      }
+    );
+  }
+
+  public updateVersion(version?: Readonly<string>): void {
+    this._appConfigCoreService.version = this._configService.getUpdatedString({
+      context: this._serviceName,
+      newValue: version,
+      oldValue: this._appConfigService.getVersion(),
+      valueName: AppConfigValueNameEnum.VERSION,
+    });
   }
 
   private _setProductionState(): void {

--- a/src/features/app/services/config/app-config-query.service.spec.ts
+++ b/src/features/app/services/config/app-config-query.service.spec.ts
@@ -53,87 +53,6 @@ describe(`AppConfigQueryService`, (): void => {
     });
   });
 
-  describe(`getReleaseDateHumanized()`, (): void => {
-    beforeEach((): void => {
-      service = AppConfigQueryService.getInstance();
-      appConfigCoreService.releaseDate = `dummy-release-date`;
-    });
-
-    describe(`when the app config release date is an empty string`, (): void => {
-      beforeEach((): void => {
-        appConfigCoreService.releaseDate = ``;
-      });
-
-      it(`should return an empty string`, (): void => {
-        expect.assertions(1);
-
-        const result = service.getReleaseDateHumanized();
-
-        expect(result).toStrictEqual(``);
-      });
-    });
-
-    describe(`when the app config release date is "unknown"`, (): void => {
-      beforeEach((): void => {
-        appConfigCoreService.releaseDate = `unknown`;
-      });
-
-      it(`should return "unknown"`, (): void => {
-        expect.assertions(1);
-
-        const result = service.getReleaseDateHumanized();
-
-        expect(result).toStrictEqual(`unknown`);
-      });
-    });
-
-    describe(`when the app config release date is a date as now`, (): void => {
-      beforeEach((): void => {
-        appConfigCoreService.releaseDate = moment().format();
-      });
-
-      it(`should return the app config release date capitalized and humanized to a few seconds`, (): void => {
-        expect.assertions(1);
-
-        const result = service.getReleaseDateHumanized();
-
-        expect(result).toStrictEqual(`A few seconds ago`);
-      });
-    });
-
-    describe(`when the app config release date is a date as one hour`, (): void => {
-      beforeEach((): void => {
-        appConfigCoreService.releaseDate = moment()
-          .subtract(1, `hour`)
-          .format();
-      });
-
-      it(`should return the app config release date capitalized and humanized to an hour`, (): void => {
-        expect.assertions(1);
-
-        const result = service.getReleaseDateHumanized();
-
-        expect(result).toStrictEqual(`An hour ago`);
-      });
-    });
-
-    describe(`when the app config release date is a date as two hours`, (): void => {
-      beforeEach((): void => {
-        appConfigCoreService.releaseDate = moment()
-          .subtract(2, `hour`)
-          .format();
-      });
-
-      it(`should return the app config release date capitalized and humanized to two hours`, (): void => {
-        expect.assertions(1);
-
-        const result = service.getReleaseDateHumanized();
-
-        expect(result).toStrictEqual(`2 hours ago`);
-      });
-    });
-  });
-
   describe(`getInitializationDateHumanized()`, (): void => {
     beforeEach((): void => {
       service = AppConfigQueryService.getInstance();
@@ -246,6 +165,87 @@ describe(`AppConfigQueryService`, (): void => {
         const result = service.getProductionStateHumanized();
 
         expect(result).toStrictEqual(`production`);
+      });
+    });
+  });
+
+  describe(`getReleaseDateHumanized()`, (): void => {
+    beforeEach((): void => {
+      service = AppConfigQueryService.getInstance();
+      appConfigCoreService.releaseDate = `dummy-release-date`;
+    });
+
+    describe(`when the app config release date is an empty string`, (): void => {
+      beforeEach((): void => {
+        appConfigCoreService.releaseDate = ``;
+      });
+
+      it(`should return an empty string`, (): void => {
+        expect.assertions(1);
+
+        const result = service.getReleaseDateHumanized();
+
+        expect(result).toStrictEqual(``);
+      });
+    });
+
+    describe(`when the app config release date is "unknown"`, (): void => {
+      beforeEach((): void => {
+        appConfigCoreService.releaseDate = `unknown`;
+      });
+
+      it(`should return "unknown"`, (): void => {
+        expect.assertions(1);
+
+        const result = service.getReleaseDateHumanized();
+
+        expect(result).toStrictEqual(`unknown`);
+      });
+    });
+
+    describe(`when the app config release date is a date as now`, (): void => {
+      beforeEach((): void => {
+        appConfigCoreService.releaseDate = moment().format();
+      });
+
+      it(`should return the app config release date capitalized and humanized to a few seconds`, (): void => {
+        expect.assertions(1);
+
+        const result = service.getReleaseDateHumanized();
+
+        expect(result).toStrictEqual(`A few seconds ago`);
+      });
+    });
+
+    describe(`when the app config release date is a date as one hour`, (): void => {
+      beforeEach((): void => {
+        appConfigCoreService.releaseDate = moment()
+          .subtract(1, `hour`)
+          .format();
+      });
+
+      it(`should return the app config release date capitalized and humanized to an hour`, (): void => {
+        expect.assertions(1);
+
+        const result = service.getReleaseDateHumanized();
+
+        expect(result).toStrictEqual(`An hour ago`);
+      });
+    });
+
+    describe(`when the app config release date is a date as two hours`, (): void => {
+      beforeEach((): void => {
+        appConfigCoreService.releaseDate = moment()
+          .subtract(2, `hour`)
+          .format();
+      });
+
+      it(`should return the app config release date capitalized and humanized to two hours`, (): void => {
+        expect.assertions(1);
+
+        const result = service.getReleaseDateHumanized();
+
+        expect(result).toStrictEqual(`2 hours ago`);
       });
     });
   });

--- a/src/features/app/services/config/app-config-query.service.ts
+++ b/src/features/app/services/config/app-config-query.service.ts
@@ -24,16 +24,6 @@ export class AppConfigQueryService extends AbstractService {
     super(ServiceNameEnum.APP_CONFIG_QUERY_SERVICE);
   }
 
-  public getReleaseDateHumanized(): string {
-    const releaseDate: string = this._appConfigService.getReleaseDate();
-
-    if (isValidDate(releaseDate)) {
-      return this._timeService.fromNow(releaseDate);
-    }
-
-    return releaseDate;
-  }
-
   public getInitializationDateHumanized(): string {
     const initializationDate: string = this._appConfigService.getInitializationDate();
 
@@ -48,6 +38,16 @@ export class AppConfigQueryService extends AbstractService {
     return this._appConfigService.isProduction()
       ? AppProductionStateEnum.PRODUCTION
       : AppProductionStateEnum.DEVELOPMENT;
+  }
+
+  public getReleaseDateHumanized(): string {
+    const releaseDate: string = this._appConfigService.getReleaseDate();
+
+    if (isValidDate(releaseDate)) {
+      return this._timeService.fromNow(releaseDate);
+    }
+
+    return releaseDate;
   }
 
   public getTotalReleaseCountHumanized(): string {

--- a/src/features/discord/activities/services/discord-activity-sonia.service.ts
+++ b/src/features/discord/activities/services/discord-activity-sonia.service.ts
@@ -50,7 +50,7 @@ export class DiscordActivitySoniaService extends AbstractService {
 
   public setPresence(
     presenceActivity: Readonly<IDiscordPresenceActivity>
-  ): Promise<Presence | void> {
+  ): Promise<Presence> {
     const clientUser: ClientUser | null = this._discordClientService.getClient()
       .user;
 
@@ -78,7 +78,7 @@ export class DiscordActivitySoniaService extends AbstractService {
           }
         )
         .catch(
-          (error: Readonly<Error | string>): Promise<void> => {
+          (error: Readonly<Error | string>): Promise<never> => {
             this._loggerService.error({
               context: this._serviceName,
               message: this._chalkService.text(

--- a/src/features/github/functions/queries/get-github-query-release-by-tag-and-total-count.spec.ts
+++ b/src/features/github/functions/queries/get-github-query-release-by-tag-and-total-count.spec.ts
@@ -15,7 +15,7 @@ describe(`getGithubQueryReleaseByTagAndTotalCount()`, (): void => {
 
       expect(result)
         .toStrictEqual(`{repository(owner: "Sonia-corporation", name: "il-est-midi-discord") {
-    release(tagName: "1.0.0") {
+   release(tagName: "1.0.0") {
       description
       updatedAt
    }

--- a/src/features/github/functions/queries/get-github-query-release-by-tag-and-total-count.spec.ts
+++ b/src/features/github/functions/queries/get-github-query-release-by-tag-and-total-count.spec.ts
@@ -1,0 +1,28 @@
+import { getGithubQueryReleaseByTagAndTotalCount } from "./get-github-query-release-by-tag-and-total-count";
+
+describe(`getGithubQueryReleaseByTagAndTotalCount()`, (): void => {
+  let tagName: string;
+
+  describe(`when the given tag name is "1.0.0"`, (): void => {
+    beforeEach((): void => {
+      tagName = `1.0.0`;
+    });
+
+    it(`should return a query to fetch the GitHub total release count and the release with the given tag name`, (): void => {
+      expect.assertions(1);
+
+      const result = getGithubQueryReleaseByTagAndTotalCount(tagName);
+
+      expect(result)
+        .toStrictEqual(`{repository(owner: "Sonia-corporation", name: "il-est-midi-discord") {
+    release(tagName: "1.0.0") {
+      description
+      updatedAt
+   }
+   releases {
+      totalCount
+   }
+}}`);
+    });
+  });
+});

--- a/src/features/github/functions/queries/get-github-query-release-by-tag-and-total-count.ts
+++ b/src/features/github/functions/queries/get-github-query-release-by-tag-and-total-count.ts
@@ -1,0 +1,15 @@
+import { getGithubRepository } from "../get-github-repository";
+
+export function getGithubQueryReleaseByTagAndTotalCount(
+  tagName: Readonly<string>
+): string {
+  return `{${getGithubRepository()} {
+   release(tagName: "${tagName}") {
+      description
+      updatedAt
+   }
+   releases {
+      totalCount
+   }
+}}`;
+}

--- a/src/features/github/interfaces/github-release-and-total-count.ts
+++ b/src/features/github/interfaces/github-release-and-total-count.ts
@@ -1,0 +1,13 @@
+export interface IGithubReleaseAndTotalCount {
+  data: {
+    repository: {
+      release?: {
+        description: string;
+        updatedAt: string;
+      };
+      releases: {
+        totalCount: number;
+      };
+    };
+  };
+}

--- a/src/features/github/interfaces/github-releases-latest-and-total-count.ts
+++ b/src/features/github/interfaces/github-releases-latest-and-total-count.ts
@@ -1,4 +1,4 @@
-export interface IGithubReleasesLatest {
+export interface IGithubReleasesLatestAndTotalCount {
   data: {
     repository: {
       releases: {

--- a/src/features/init/services/init.service.ts
+++ b/src/features/init/services/init.service.ts
@@ -9,13 +9,14 @@ import { IEnvironment } from "../../../environment/interfaces/environment";
 import { getBearer } from "../../../functions/formatters/get-bearer";
 import { IPackage } from "../../../interfaces/package";
 import { AppConfigMutatorService } from "../../app/services/config/app-config-mutator.service";
+import { AppConfigService } from "../../app/services/config/app-config.service";
 import { DiscordMessageConfigMutatorService } from "../../discord/messages/services/config/discord-message-config-mutator.service";
 import { DiscordService } from "../../discord/services/discord.service";
 import { DiscordSoniaConfigMutatorService } from "../../discord/users/services/config/discord-sonia-config-mutator.service";
 import { GITHUB_API_URL } from "../../github/constants/github-api-url";
-import { GITHUB_QUERY_RELEASES_LATEST_AND_TOTAL_COUNT } from "../../github/constants/queries/github-query-releases-latest-and-total-count";
 import { getHumanizedReleaseNotes } from "../../github/functions/get-humanized-release-notes";
-import { IGithubReleasesLatest } from "../../github/interfaces/github-releases-latest";
+import { getGithubQueryReleaseByTagAndTotalCount } from "../../github/functions/queries/get-github-query-release-by-tag-and-total-count";
+import { IGithubReleaseAndTotalCount } from "../../github/interfaces/github-release-and-total-count";
 import { GithubConfigMutatorService } from "../../github/services/config/github-config-mutator.service";
 import { GithubConfigService } from "../../github/services/config/github-config.service";
 import { ChalkService } from "../../logger/services/chalk.service";
@@ -62,8 +63,9 @@ export class InitService extends AbstractService {
 
   private _configureApp(environment: Readonly<IEnvironment>): void {
     this._configureAppFromEnvironment(environment);
-    this._configureAppFromPackage();
-    this._configureAppFromGitHubReleases();
+    this._configureAppFromPackage().then((): void => {
+      this._configureAppFromGitHubReleases();
+    });
   }
 
   private _configureAppFromEnvironment(
@@ -82,25 +84,47 @@ export class InitService extends AbstractService {
     ServerConfigMutatorService.getInstance().init();
   }
 
-  private _configureAppFromPackage(): void {
-    fs.readJson(`${appRootPath}/package.json`)
-      .then((data: Readonly<IPackage>): void => {
-        AppConfigMutatorService.getInstance().updateVersion(data.version);
-      })
-      .catch((error: unknown): void => {
-        this._loggerService.error({
-          message: this._chalkService.text(`Failed to read the package file`),
-        });
-        this._loggerService.error({
-          message: this._chalkService.text(error),
-        });
-      });
+  private _configureAppFromPackage(): Promise<IPackage> {
+    return fs
+      .readJson(`${appRootPath}/package.json`)
+      .then(
+        (data: Readonly<IPackage>): Promise<IPackage> => {
+          AppConfigMutatorService.getInstance().updateVersion(data.version);
+
+          return Promise.resolve(data);
+        }
+      )
+      .catch(
+        (error: unknown): Promise<never> => {
+          this._loggerService.error({
+            context: this._serviceName,
+            message: this._chalkService.text(`Failed to read the package file`),
+          });
+          this._loggerService.error({
+            context: this._serviceName,
+            message: this._chalkService.text(error),
+          });
+
+          return Promise.reject(error);
+        }
+      );
   }
 
-  private _configureAppFromGitHubReleases(): void {
-    axios({
+  private _configureAppFromGitHubReleases(): Promise<
+    IGithubReleaseAndTotalCount
+  > {
+    const appVersion: string = AppConfigService.getInstance().getVersion();
+
+    this._loggerService.debug({
+      context: this._serviceName,
+      message: this._chalkService.text(
+        `App version: ${this._chalkService.value(appVersion)}`
+      ),
+    });
+
+    return axios({
       data: {
-        query: GITHUB_QUERY_RELEASES_LATEST_AND_TOTAL_COUNT,
+        query: getGithubQueryReleaseByTagAndTotalCount(appVersion),
       },
       headers: {
         authorization: getBearer(
@@ -110,47 +134,101 @@ export class InitService extends AbstractService {
       method: `post`,
       url: GITHUB_API_URL,
     })
-      .then((axiosResponse: AxiosResponse<IGithubReleasesLatest>): void => {
-        AppConfigMutatorService.getInstance().updateTotalReleaseCount(
-          axiosResponse.data.data.repository.releases.totalCount
-        );
-        AppConfigMutatorService.getInstance().updateReleaseDate(
-          axiosResponse.data.data.repository.releases.edges[0].node.updatedAt
-        );
-        AppConfigMutatorService.getInstance().updateReleaseNotes(
-          getHumanizedReleaseNotes(
-            axiosResponse.data.data.repository.releases.edges[0].node
-              .description
-          )
-        );
-      })
-      .catch((): void => {
-        this._loggerService.error({
-          message: this._chalkService.text(
-            `Failed to get the app total release count from GitHub API`
-          ),
-        });
-      });
+      .then(
+        (
+          axiosResponse: AxiosResponse<IGithubReleaseAndTotalCount>
+        ): Promise<IGithubReleaseAndTotalCount> => {
+          AppConfigMutatorService.getInstance().updateTotalReleaseCount(
+            axiosResponse.data.data.repository.releases.totalCount
+          );
+
+          this._loggerService.success({
+            context: this._serviceName,
+            message: this._chalkService.text(
+              `Total release count updated from GitHub API`
+            ),
+          });
+
+          if (!_.isNil(axiosResponse.data.data.repository.release)) {
+            AppConfigMutatorService.getInstance().updateReleaseDate(
+              axiosResponse.data.data.repository.release.updatedAt
+            );
+            AppConfigMutatorService.getInstance().updateReleaseNotes(
+              getHumanizedReleaseNotes(
+                axiosResponse.data.data.repository.release.description
+              )
+            );
+
+            this._loggerService.success({
+              context: this._serviceName,
+              message: this._chalkService.text(
+                `Release notes updated from GitHub API`
+              ),
+            });
+          } else {
+            this._loggerService.error({
+              context: this._serviceName,
+              message: this._chalkService.text(
+                `Failed to find a release with the given tag name from GitHub API`
+              ),
+            });
+          }
+
+          return Promise.resolve(axiosResponse.data);
+        }
+      )
+      .catch(
+        (error: unknown): Promise<never> => {
+          this._loggerService.error({
+            context: this._serviceName,
+            message: this._chalkService.text(
+              `Failed to get the total release count from GitHub API`
+            ),
+          });
+          this._loggerService.error({
+            context: this._serviceName,
+            message: this._chalkService.text(
+              `Failed to get the release notes for the app version from GitHub API`
+            ),
+          });
+          this._loggerService.error({
+            context: this._serviceName,
+            message: this._chalkService.text(error),
+          });
+
+          return Promise.reject(error);
+        }
+      );
   }
 
-  private _readEnvironment(): void {
-    fs.readJson(`${appRootPath}/src/environment/secret-environment.json`)
-      .then((environment: Readonly<IEnvironment>): void => {
-        this._startApp(this._mergeEnvironments(ENVIRONMENT, environment));
-      })
-      .catch((error: unknown): void => {
-        console.error(`Failed to read the secret environment file`);
-        console.error(error);
-        console.debug(
-          `Follow the instructions about the secret environment to fix this:`
-        );
-        console.debug(
-          `https://github.com/Sonia-corporation/il-est-midi-discord/blob/master/CONTRIBUTING.md#create-the-secret-environment-file`
-        );
-        throw new Error(
-          `The app must have a secret environment file with at least a "discord.sonia.secretToken" inside it`
-        );
-      });
+  private _readEnvironment(): Promise<IEnvironment> {
+    return fs
+      .readJson(`${appRootPath}/src/environment/secret-environment.json`)
+      .then(
+        (environment: Readonly<IEnvironment>): Promise<IEnvironment> => {
+          this._startApp(this._mergeEnvironments(ENVIRONMENT, environment));
+
+          return Promise.resolve(environment);
+        }
+      )
+      .catch(
+        (error: unknown): Promise<never> => {
+          console.error(`Failed to read the secret environment file`);
+          console.error(error);
+          console.debug(
+            `Follow the instructions about the secret environment to fix this:`
+          );
+          console.debug(
+            `https://github.com/Sonia-corporation/il-est-midi-discord/blob/master/CONTRIBUTING.md#create-the-secret-environment-file`
+          );
+
+          return Promise.reject(
+            new Error(
+              `The app must have a secret environment file with at least a "discord.sonia.secretToken" inside it`
+            )
+          );
+        }
+      );
   }
 
   private _startApp(environment: Readonly<IEnvironment>): void {


### PR DESCRIPTION
before that, the release notes were always the one from the latest version of Sonia
this was problematic when using an old version on local dev
also enhance the return types to return promise more often to avoid anti-pattern

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](https://github.com/Sonia-corporation/il-est-midi-discord/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added/updated (for bugfix/feature)
- [ ] Docs have been added/updated (for bugfix/feature)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Feature (a new feature)
- [x] Bugfix (a bug fix)
- [ ] Style (changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc))
- [x] Refactor (a code change that neither fixes a bug nor adds a feature)
- [ ] Perf (a code change that improves performance)
- [ ] Test (adding missing tests or correcting existing tests)
- [ ] Build (changes that affect the build system, CI configuration or external dependencies)
- [ ] Chore (anything else), please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Fixes #434.